### PR TITLE
Update the 'activerecord' dependency

### DIFF
--- a/each_in_batches.gemspec
+++ b/each_in_batches.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 3.2"
+  spec.add_dependency "activerecord", ">= 3.2", "< 5.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
This makes the gem work with Rails 4+ (instead of Rails 3.2+)
